### PR TITLE
make all necessary dirs at outset of build script

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "roadtrip": "^0.5.0"
   },
   "scripts": {
-    "build:all": "rm -rf dist && mkdir -p dist && npm run build:server && npm run build:client && npm run build:sw",
+    "build:all": "rm -rf dist && mkdir -p dist server/manifests && npm run build:server && npm run build:client && npm run build:sw",
     "build:server": "node build",
     "build:client": "rollup -c client/rollup.config.js",
     "build:sw": "rollup -c service-worker/rollup.config.js",


### PR DESCRIPTION
On a fresh clone, build fails because `server/manifests` directory [doesn't exist](https://github.com/sveltejs/svelte-hackernews/blob/master/.gitignore#L5) but is [written into](https://github.com/sveltejs/svelte-hackernews/blob/master/client/rollup.config.js#L32).